### PR TITLE
Remove default entity profile

### DIFF
--- a/remote_case.php
+++ b/remote_case.php
@@ -6,10 +6,8 @@ require_once 'remote_case.civix.php';
 // phpcs:enable
 
 use Civi\RemoteCase\Api4\Permissions;
-use Civi\RemoteCase\RemoteCaseDefaultEntityProfile;
-use Civi\RemoteTools\EntityProfile\ReadOnlyRemoteEntityProfile;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use CRM_RemoteCase_ExtensionUtil as E;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Implements hook_civicrm_config().
@@ -24,9 +22,8 @@ function remote_case_civicrm_config(\CRM_Core_Config $config): void {
  * Implements hook_civicrm_container().
  */
 function remote_case_civicrm_container(ContainerBuilder $container): void {
-  if (class_exists(ReadOnlyRemoteEntityProfile::class)) {
-    $container->autowire(RemoteCaseDefaultEntityProfile::class)
-      ->addTag(RemoteCaseDefaultEntityProfile::SERVICE_TAG);
+  if (function_exists('_remote_case_test_civicrm_container')) {
+    _remote_case_test_civicrm_container($container);
   }
 }
 

--- a/tests/phpunit/Civi/Api4/RemoteCaseTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteCaseTest.php
@@ -26,7 +26,7 @@ use Civi\RemoteCase\Fixtures\ContactFixture;
 
 /**
  * @covers \Civi\Api4\RemoteCase
- * @covers \Civi\RemoteCase\RemoteCaseDefaultEntityProfile
+ * @covers \Civi\RemoteCase\RemoteCaseTestEntityProfile
  *
  * @group headless
  */
@@ -36,7 +36,7 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
     $contact = ContactFixture::addIndividual();
     $case = CaseFixture::addFixture($contact['id']);
     $result = RemoteCase::delete()
-      ->setProfile('default')
+      ->setProfile('test')
       ->addWhere('id', '=', $case['id'])
       ->execute();
 
@@ -45,7 +45,7 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
 
   public function testGet(): void {
     $result = RemoteCase::get()
-      ->setProfile('default')
+      ->setProfile('test')
       ->execute();
 
     static::assertCount(0, $result);
@@ -53,7 +53,7 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
     $contact = ContactFixture::addIndividual();
     $case = CaseFixture::addFixture($contact['id']);
     $result = RemoteCase::get()
-      ->setProfile('default')
+      ->setProfile('test')
       ->addSelect('*', 'CAN_delete', 'CAN_update')
       ->execute();
 
@@ -63,7 +63,7 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
     static::assertFalse($result->single()['CAN_update']);
 
     $result = RemoteCase::get()
-      ->setProfile('default')
+      ->setProfile('test')
       ->addWhere('id', '!=', $case['id'])
       ->execute();
 
@@ -79,13 +79,13 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
   public function testGetCreateForm(): void {
     $this->expectException(UnauthorizedException::class);
     RemoteCase::getCreateForm()
-      ->setProfile('default')
+      ->setProfile('test')
       ->execute();
   }
 
   public function testGetFields(): void {
     $result = RemoteCase::getFields()
-      ->setProfile('default')
+      ->setProfile('test')
       ->addSelect('*', 'CAN_delete', 'CAN_update')
       ->execute();
 
@@ -100,7 +100,7 @@ final class RemoteCaseTest extends AbstractRemoteCaseHeadlessTestCase {
     $case = CaseFixture::addFixture($contact['id']);
     $this->expectException(UnauthorizedException::class);
     RemoteCase::getUpdateForm()
-      ->setProfile('default')
+      ->setProfile('test')
       ->setId($case['id'])
       ->execute();
   }

--- a/tests/phpunit/Civi/RemoteCase/RemoteCaseTestEntityProfile.php
+++ b/tests/phpunit/Civi/RemoteCase/RemoteCaseTestEntityProfile.php
@@ -21,9 +21,9 @@ namespace Civi\RemoteCase;
 
 use Civi\RemoteTools\EntityProfile\ReadOnlyRemoteEntityProfile;
 
-final class RemoteCaseDefaultEntityProfile extends ReadOnlyRemoteEntityProfile {
+final class RemoteCaseTestEntityProfile extends ReadOnlyRemoteEntityProfile {
 
-  public const NAME = 'default';
+  public const NAME = 'test';
 
   public const ENTITY_NAME = 'Case';
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types = 1);
 
+use Civi\RemoteCase\RemoteCaseTestEntityProfile;
 use Composer\Autoload\ClassLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -52,6 +53,8 @@ if (!function_exists('ts')) {
  * Modify DI container for tests.
  */
 function _remote_case_test_civicrm_container(ContainerBuilder $container): void {
+  $container->autowire(RemoteCaseTestEntityProfile::class)
+    ->addTag(RemoteCaseTestEntityProfile::SERVICE_TAG);
 }
 
 function addExtensionToClassLoader(string $extension): void {


### PR DESCRIPTION
The default profile might allow users to see cases they aren't allowed to see.